### PR TITLE
update build

### DIFF
--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -7,7 +7,7 @@ ARG UBUNTU_CODENAME=jammy
 
 FROM ubuntu:22.04 as base
 
-ARG PACKAGES=ca-certificates\ git
+ARG PACKAGES=ca-certificates\ git\ netbase\ openjdk-17-jre-headless
 ARG DUMB_INIT_VERSION="1.2.5"
 ARG TARGETARCH
 


### PR DESCRIPTION
- pre install lts openjdk 17 so the puppetserver dependency does not install openjdk 1.8
- add netbase, otherwise puppetserver startup will fail because /etc/protocols is missing