### PR TITLE
Add support for generating additional certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ on that hostname by default.
 If you would like to start the Puppet Server with your own Puppet code, you can
 mount your own directory at `/etc/puppetlabs/code`:
 
-    docker run --name puppet --hostname puppet -v ./code:/etc/puppetlabs/code/ ghcr.io/voxpupuli/container-puppetserver:v1.0.0-7
+```bash
+docker run --name puppet --hostname puppet -v ./code:/etc/puppetlabs/code/ ghcr.io/voxpupuli/container-puppetserver:v1.0.0-7
+```
 
 For compose file see: [CRAFTY](https://github.com/voxpupuli/crafty/tree/main/puppet/oss)
 
 You can find out more about Puppet Server in the [official documentation](https://www.puppet.com/docs/puppet/7/server/about_server.html).
-
 
 ## Configuration
 
@@ -61,6 +62,7 @@ The following environment variables are supported:
 | **PUPPETDB_SERVER_URLS**                   | The `server_urls` to set in `/etc/puppetlabs/puppet/puppetdb.conf`<br><br>`https://puppetdb:8081`                                                             |
 | **PUPPETDB_HOSTNAME**                      | The DNS name of the puppetdb <br><br> Defaults to `puppetdb`                                                                                                  |
 | **PUPPETDB_SSL_PORT**                      | The TLS port of the puppetdb <br><br> Defaults to `8081`                                                                                                      |
+| **ADDITIONAL_CERTIFICATES**                   | Generate and sign additional certificates                                                                                                                     |
 
 ## Initialization Scripts
 

--- a/puppetserver/docker-entrypoint.d/86-generate-additional-certs.sh
+++ b/puppetserver/docker-entrypoint.d/86-generate-additional-certs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if test -n "${ADDITIONAL_CERTIFICATES}" ; then
+  # split string into array
+  IFS=',' read -ra certnames <<< "$ADDITIONAL_CERTIFICATES"
+
+  for i in "${certnames[@]}"; do
+    echo "Generating: $i"
+    # use force to gen cert while puppetserver is still offline
+    # puppetserver will always fail, because it tries to connect to the API
+    # so we add || true to ignore the error
+    # if the cert already exists, it will not be overwritten
+    # puppetserver acknowledges the cert and continue
+    puppetserver ca generate --certname $i --force || true
+  done
+fi


### PR DESCRIPTION
Add possibility to pregenerate and sign certificates for agents/API in the puppet ca.
The command will always output some error text, because it will always try to connect to the api on 8140, but this is not running yet.

If certificate does not yet exist:

```
Generating: test
Fatal error when running action 'generate'
  Error: Failed connecting to https://puppet:8140/puppet-ca/v1/certificate_request/
  Root cause: Failed to open TCP connection to puppet:8140 (Connection refused - connect(2) for "puppet" port 8140)
Successfully saved private key for test to /etc/puppetlabs/puppet/ssl/private_keys/test.pem
Successfully saved public key for test to /etc/puppetlabs/puppet/ssl/public_keys/test.pem
```

If certificate already exists
```
Generating: puppetboard
Error:
Existing file at '/etc/puppetlabs/puppet/ssl/private_keys/puppetboard.pem'
Existing file at '/etc/puppetlabs/puppet/ssl/public_keys/puppetboard.pem'
Please delete these files if you really want to generate a new cert for puppetboard.
```

Command:

```bash
docker run --rm \
  --name puppet \
  -e ADDITIONAL_CERTIFICATES="puppetboard,robert,test" \
  --hostname puppet ghcr.io/voxpupuli/container-puppetserver:main-7
```