### PR TITLE
enable admin-api to clear cache in auth.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ The following environment variables are supported:
 | **PUPPETDB_HOSTNAME**                      | The DNS name of the puppetdb <br><br> Defaults to `puppetdb`                                                                                                  |
 | **PUPPETDB_SSL_PORT**                      | The TLS port of the puppetdb <br><br> Defaults to `8081`                                                                                                      |
 | **PUPPETSERVER_GRAPHITE_EXPORTER_ENABLED** | Activate the graphite exporter. Also needs **PUPPETSERVER_GRAPHITE_HOST** and **PUPPETSERVER_GRAPHITE_PORT**<br><br>  Defaults to `false`                     |
-| **PUPPETSERVER_GRAPHITE_HOST**             | Only used if **PUPPETSERVER_GRAPHITE_EXPORTER_ENABLED** is set to `true`. FQDN or Hostname of the graphite server where puppet should push metrics to. <br><br> Default to `exporter` |
+| **PUPPETSERVER_GRAPHITE_HOST**             | Only used if **PUPPETSERVER_GRAPHITE_EXPORTER_ENABLED** is set to `true`. FQDN or Hostname of the graphite server where puppet should push metrics to. <br><br> Defaults to `exporter` |
 | **PUPPETSERVER_GRAPHITE_PORT**             | Only used if **PUPPETSERVER_GRAPHITE_EXPORTER_ENABLED** is set to `true`. Port of the graphite server where puppet should push metrics to. <br><br> Default to `9109` |
 | **PUPPETSERVER_ENVIRONMENT_TIMEOUT**       | Configure the environment timeout<br><br> Defaults to `unlimited`                                                                                             |
+| **PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API**  | Enable the puppet admin api endpoint via certificates to allow clearing environment caches<br><br> Defaults to `true`                                         |
 
 ## Initialization Scripts
 

--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -41,7 +41,8 @@ ENV PUPPETSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
     PUPPETSERVER_GRAPHITE_EXPORTER_ENABLED=false \
     PUPPETSERVER_GRAPHITE_PORT=9109 \
     PUPPETSERVER_GRAPHITE_HOST=exporter \
-    PUPPETSERVER_ENVIRONMENT_TIMEOUT=unlimited
+    PUPPETSERVER_ENVIRONMENT_TIMEOUT=unlimited \
+    PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API=true
 
 # NOTE: this is just documentation on defaults
 EXPOSE 8140
@@ -56,6 +57,7 @@ COPY docker-entrypoint.sh \
      /
 COPY docker-entrypoint.d /docker-entrypoint.d
 COPY metrics.conf.tmpl /metrics.conf.tmpl
+COPY add_cache_del_api_auth_rules.rb /add_cache_del_api_auth_rules.rb
 # k8s uses livenessProbe, startupProbe, readinessProbe and ignores HEALTHCHECK
 HEALTHCHECK --interval=20s --timeout=15s --retries=12 --start-period=3m CMD ["/healthcheck.sh"]
 

--- a/puppetserver/add_cache_del_api_auth_rules.rb
+++ b/puppetserver/add_cache_del_api_auth_rules.rb
@@ -1,0 +1,29 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'hocon/parser/config_document_factory'
+require 'hocon/config_value_factory'
+
+auth_conf = '/etc/puppetlabs/puppetserver/conf.d/auth.conf'
+
+conf_hash = Hocon.load(auth_conf)
+conf = Hocon::Parser::ConfigDocumentFactory.parse_file(auth_conf)
+
+rule_to_add = [
+  {
+    'match-request' => {
+      'path'   => '/puppet-admin-api/v1/environment-cache',
+      'type'   => 'path',
+      'method' => 'delete'
+    },
+    'allow'      => '*',
+    'sort-order' => 500,
+    'name'       => 'puppet admin api clear caches'
+  }
+]
+
+conf_hash['authorization']['rules'] += rule_to_add
+
+new_conf = conf.set_config_value('authorization.rules', Hocon::ConfigValueFactory.from_any_ref(conf_hash['authorization']['rules']))
+
+File.open(auth_conf, 'w') { |file| file.write(new_conf.render) }
+

--- a/puppetserver/docker-entrypoint.d/88-enable-cache-delete-api.sh
+++ b/puppetserver/docker-entrypoint.d/88-enable-cache-delete-api.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+if [[ "$PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API" == true ]]; then
+  /opt/puppetlabs/puppet/bin/ruby /add_cache_del_api_auth_rules.rb
+fi


### PR DESCRIPTION
in a default installation the admin-api to delete caches is not directly enabled.
We enable the api endpoint by adding a section to puppetserver auth.conf using ruby hocon