### PR TITLE
Make setting for admin-api idempotent

### DIFF
--- a/puppetserver/docker-entrypoint.d/88-enable-cache-delete-api.sh
+++ b/puppetserver/docker-entrypoint.d/88-enable-cache-delete-api.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 #
 if [[ "$PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API" == true ]]; then
-  /opt/puppetlabs/puppet/bin/ruby /add_cache_del_api_auth_rules.rb
+  if [ $(grep 'puppet-admin-api' /etc/puppetlabs/puppetserver/conf.d/auth.conf) ]; then
+    echo "Admin API already set"
+  else
+    /opt/puppetlabs/puppet/bin/ruby /add_cache_del_api_auth_rules.rb
+  fi
 fi


### PR DESCRIPTION
if restarting the server, the shell snippets will run again a duplicate admin-api entry causes the puppetserver to not start