### PR TITLE
feat: set puppet uid/gid in container build

### DIFF
--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -96,6 +96,8 @@ FROM base as release
 ARG PUPPET_RELEASE=8
 ARG PUPPETSERVER_VERSION=8.6.1
 ARG UBUNTU_CODENAME
+ARG PUPPET_USER_UID=999
+ARG PUPPET_USER_GID=999
 
 ######################################################
 # final image
@@ -111,6 +113,10 @@ ARG build_date
 
 ENV PUPPET_DEB=puppet${PUPPET_RELEASE}-release-${UBUNTU_CODENAME}.deb
 ADD https://apt.puppet.com/${PUPPET_DEB} /${PUPPET_DEB}
+
+# Create puppet user and group with PUPPET_USER_UID and PUPPET_USER_GID
+RUN groupadd -g ${PUPPET_USER_GID} puppet && \
+    useradd -m -u ${PUPPET_USER_UID} -g puppet puppet
 
 # hadolint ignore=DL3008,DL3028
 RUN dpkg -i /${PUPPET_DEB} && \

--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -5,7 +5,7 @@ ARG UBUNTU_CODENAME=jammy
 # base
 ######################################################
 
-FROM ubuntu:22.04 as base
+FROM ubuntu:22.04 AS base
 
 ARG PACKAGES="ca-certificates git netbase openjdk-17-jre-headless ruby3.0 openssh-client"
 ARG BUILD_PKGS="ruby3.0-dev gcc make cmake pkg-config libssl-dev libc6-dev"
@@ -91,7 +91,7 @@ RUN chmod +x /docker-entrypoint.sh /healthcheck.sh /docker-entrypoint.d/*.sh && 
 # release (build from packages)
 ######################################################
 
-FROM base as release
+FROM base AS release
 
 ARG PUPPET_RELEASE=8
 ARG PUPPETSERVER_VERSION=8.6.1
@@ -105,7 +105,7 @@ ARG PUPPET_USER_GID=999
 
 # dynamically selects "edge" or "release" alias based on ARG
 # hadolint ignore=DL3006
-FROM ${build_type} as final
+FROM ${build_type} AS final
 
 ARG vcs_ref
 ARG build_type


### PR DESCRIPTION
I want to connect an EFS to the ECS Service for the ca mountpoint and by creating an access point and setting ownership and permissions, we can have EFS create a directory for us, and make sure we always use the same UID/GID when accessing files. That makes re-deploys of the stack possible without user id issues…

For this to be possible we must be certain the UID/GID are static.
Just setting these at build time makes this possible.