### PR TITLE
Don't let the entry scripts fail if there is no cert (dir)

### DIFF
--- a/puppetserver/docker-entrypoint.d/70-set-dns-alt-names.sh
+++ b/puppetserver/docker-entrypoint.d/70-set-dns-alt-names.sh
@@ -2,13 +2,15 @@
 
 set -e
 
+config_section=main
+
 # Allow setting dns_alt_names for the compilers certificate. This
 # setting will only have an effect when the container is started without
 # an existing certificate on the /etc/puppetlabs/puppet volume
-if [ -n "${DNS_ALT_NAMES}" ] && [ "${CA_ENABLED}" != "true" ]; then
+if [ -n "${DNS_ALT_NAMES}" ]; then
     certname=$(puppet config print certname)
     if test ! -f "${SSLDIR}/certs/$certname.pem" ; then
-        puppet config set dns_alt_names "${DNS_ALT_NAMES}" --section agent
+        puppet config set dns_alt_names "${DNS_ALT_NAMES}" --section "${config_section}"
     else
         actual=$(puppet config print dns_alt_names --section "${config_section}")
         if test "${DNS_ALT_NAMES}" != "${actual}" ; then


### PR DESCRIPTION
Having a fail will fail the entire instance.
When the certs (dir) is missing, it gets recreated at puppetserver startup anyway.