### PR TITLE
Feature/puppet masterport setting

### DIFF
--- a/puppetserver/docker-entrypoint.d/55-set-masterport.sh
+++ b/puppetserver/docker-entrypoint.d/55-set-masterport.sh
@@ -9,5 +9,7 @@ hocon() {
 if test -n "$PUPPETSERVER_PORT"; then
   cd /etc/puppetlabs/puppetserver/conf.d/
   hocon -f webserver.conf set webserver.ssl-port $PUPPETSERVER_PORT
+  cd /etc/puppetlabs/puppet/
+  hocon -f puppet.conf set serverport $PUPPETSERVER_PORT
   cd /
 fi


### PR DESCRIPTION
Also set serverport in puppet.conf
That way, local commands, like `puppetserver ca <cmd>` also work.
https://www.puppet.com/docs/puppet/8/configuration#serverport
