### PR TITLE
Feature/updates vrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following environment variables are supported:
 | __PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API__  | Enable the puppet admin api endpoint via certificates to allow clearing environment caches<br><br> Defaults to `true`                                         |
 | __ENVIRONMENTPATH__                        | Set an environmentpath<br><br> Defaults to `/etc/puppetlabs/code/environments`                                                                                |
 | __HIERACONFIG__                            | Set a hiera_config entry in puppet.conf file<br><br> Defaults to `$confdir/hiera.yaml`                                                                        |
-| __CSR_ATTRIBUTES__                         | Provide a JSON string of the csr_attributes.yaml content. e.g. `CSR_ATTRIBUTES='{"custom_attributes": { "challengePassword": "foobar" }, "extension_requests": { "pp_project": "foo" } }'`<br><br> Defaults to empty JSON object `{}`<br> Please note that within a compose file, you must provide all environment variables as Hash and not as Array!<br> environment:<br> `CSR_ATTRIBUTES: '{"extension_request": {...}}'` |
+| __CSR_ATTRIBUTES__                         | Provide a JSON string of the csr_attributes.yaml content. e.g. `CSR_ATTRIBUTES='{"custom_attributes": { "challengePassword": "foobar" }, "extension_requests": { "pp_project": "foo" } }'`<br><br> Please note that within a compose file, you must provide all environment variables as Hash and not as Array!<br> environment:<br> `CSR_ATTRIBUTES: '{"extension_request": {...}}'` |
 
 ## Initialization Scripts
 
@@ -129,6 +129,7 @@ If you would like to do additional initialization, add a directory called `/dock
 
 You can also create sub-directories in `/docker-custom-entrypoint.d/` for scripts that have to run at different stages.
 
+- `/docker-custom-entrypoint.d/pre-default/` - scripts that run before the default entrypoint scripts from this repo run.
 - `/docker-custom-entrypoint.d/` - scripts that run after the default entrypoint scripts, but before the puppetserver service is started.
 - `/docker-custom-entrypoint.d/post-startup/` - scripts that run after the puppetserver service is started.
 - `/docker-custom-entrypoint.d/sigterm-handler/` - scripts that run when the container receives a SIGTERM signal.

--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -65,7 +65,7 @@ ENV PUPPETSERVER_JAVA_ARGS="-Xms1024m -Xmx1024m" \
     PUPPETSERVER_ENABLE_ENV_CACHE_DEL_API=true \
     ENVIRONMENTPATH=/etc/puppetlabs/code/environments \
     HIERACONFIG='$confdir/hiera.yaml' \
-    CSR_ATTRIBUTES='{}' \
+    CSR_ATTRIBUTES="" \
     PUPPET_DEB=puppet${PUPPET_RELEASE}-release-${UBUNTU_CODENAME}.deb
 
 COPY docker-entrypoint.sh \

--- a/puppetserver/conf.d/puppetserver.conf
+++ b/puppetserver/conf.d/puppetserver.conf
@@ -75,7 +75,7 @@ http-client: {
 # Provide a reasonable default here. Use case is mounting a valid projects volume to have PS serve files from there even if
 # CM did not actually put them there.
 bolt: {
-  projects-dir: "/etc/puppetlabs/code/projects"
+    projects-dir: "/etc/puppetlabs/code/projects"
 }
 
 # settings related to profiling the puppet Ruby code

--- a/puppetserver/docker-entrypoint.d/89-csr_attributes.sh
+++ b/puppetserver/docker-entrypoint.d/89-csr_attributes.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-echo "CSR Attributes: ${CSR_ATTRIBUTES}"
-/opt/puppetlabs/puppet/bin/ruby /docker-entrypoint.d/89-csr_attributes.rb
+if [ -n "${CSR_ATTRIBUTES}" ]; then
+    echo "CSR Attributes: ${CSR_ATTRIBUTES}"
+    /opt/puppetlabs/puppet/bin/ruby /docker-entrypoint.d/89-csr_attributes.rb
+fi

--- a/puppetserver/docker-entrypoint.sh
+++ b/puppetserver/docker-entrypoint.sh
@@ -19,10 +19,25 @@ echoerr "Entrypoint PID $$"
 
 ## Pre execution handler
 pre_execution_handler() {
+  if [ -d /docker-custom-entrypoint.d/ ]; then
+    if [ -d /docker-custom-entrypoint.d/pre-default/ ]; then
+      find /docker-custom-entrypoint.d/pre-default/ -type f -name "*.sh" \
+        -exec chmod +x {} \;
+      sync
+      for f in /docker-custom-entrypoint.d/pre-default/*.sh; do
+        if [[ -f "$f" && -x $(realpath "$f") ]]; then
+          echo "Running $f"
+          "$f"
+        fi
+      done
+    fi
+  fi
+
   for f in /docker-entrypoint.d/*.sh; do
     echo "Running $f"
     "$f"
   done
+
   if [ -d /docker-custom-entrypoint.d/ ]; then
     find /docker-custom-entrypoint.d/ -type f -name "*.sh" \
       -exec chmod +x {} \;


### PR DESCRIPTION
- Make indenting in puppetserver.conf consistent
- Only write csr_attributes.yaml file if the env var CSR_ATTRIBUTES has content. This file is not required for normal functioning.
- Allow running custom entrypoint scripts before the default scripts run. In this case, I need to run a script that creates csr_attributes.yaml with data from AWS ECS metadata and that needs to exist before the CA script auto-signs the server script.